### PR TITLE
fix candidate for #184

### DIFF
--- a/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/junit/JUnitReporter.java
+++ b/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/junit/JUnitReporter.java
@@ -72,14 +72,22 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 
 	}
 
-	@Override
-	public void startTest(TestInfo testInfo) {
-		TestCase testCase = new TestCase();
-		testCase.setName(testInfo.methodName);
-		testCase.setClassName(testInfo.className);
-		testStart = System.currentTimeMillis();
-		testSuite.addTestCase(testCase);
-	}
+ 	@Override
+ 	public void startTest(TestInfo testInfo) {
+ 		TestCase testCase = new TestCase();
+
+		String methodName = testInfo.methodName;
+	
+		// if this field is null read basicName
+		// to fix "Mark scenario as Test" bug #184
+		if ( methodName == null ) 
+			methodName = testInfo.basicName;
+
+		testCase.setName(methodName);		
+ 		testCase.setClassName(testInfo.className);
+ 		testStart = System.currentTimeMillis();
+ 		testSuite.addTestCase(testCase);
+ 	}
 
 	@Override
 	public void addError(Test arg0, Throwable arg1) {


### PR DESCRIPTION
This candidate fetches before "methodName" and after "basicName" from input "TestInfo" .

The method "setName" will be called with the first one not null .

When "Mark scenario as Test" feature is used only "basicName" is not null.
