### PR TITLE
Revert "Add port attribute to SSH and use it connecting"

### DIFF
--- a/jsystem-core-system-objects/cli-so/src/main/java/com/aqua/sysobj/conn/CliConnectionImpl.java
+++ b/jsystem-core-system-objects/cli-so/src/main/java/com/aqua/sysobj/conn/CliConnectionImpl.java
@@ -265,13 +265,13 @@ public abstract class CliConnectionImpl extends SystemObjectImpl implements CliC
 			if (params.length < 5) {
 				throw new Exception("Unable to extract parameters from host: " + host);
 			}
-			terminal = new RS232(params[0], Integer.parseInt(params[1]), Integer.parseInt(params[2]), Integer.parseInt(params[3]), Integer .parseInt(params[4]));
+			terminal = new RS232(params[0], Integer.parseInt(params[1]), Integer.parseInt(params[2]), Integer.parseInt(params[3]), Integer
+					.parseInt(params[4]));
 		} else if (protocol.toLowerCase().equals(EnumConnectionType.SSH.value())) {
 			terminal = new SSH(host, user, password);
-			((SSH)terminal).setPort(port);
-		} else if (protocol.toLowerCase().equals(EnumConnectionType.SSH_RSA.value())) {
+		} else if (protocol.toLowerCase().equals(
+				EnumConnectionType.SSH_RSA.value())) {
 			terminal = new SSHWithRSA(host, user, password, privateKey);
-			((SSH)terminal).setPort(port);
 			prompts.add(new Prompt("$", false, true));
 			prompts.add(new Prompt("]$", false, true));
 			

--- a/jsystem-core-system-objects/cli-so/src/main/java/systemobject/terminal/SSH.java
+++ b/jsystem-core-system-objects/cli-so/src/main/java/systemobject/terminal/SSH.java
@@ -35,8 +35,6 @@ public class SSH extends Terminal {
 	protected int destinationPort = -1;
 	
 	protected boolean xtermTerminal = true;
-
-	protected int port = 22;
 	
 	public SSH(String hostnameP, String usernameP, String passwordP) {
 		this(hostnameP, usernameP, passwordP, -1, -1, true);
@@ -57,11 +55,11 @@ public class SSH extends Terminal {
 	}
 
 	@Override
-	public void connect(int port) throws IOException {
+	public void connect() throws IOException {
 		boolean isAuthenticated = false;
 		/* Create a connection instance */
 
-		conn = new Connection(hostname, port);
+		conn = new Connection(hostname);
 
 		/* Now connect */
 
@@ -217,15 +215,6 @@ public class SSH extends Terminal {
 
 	protected void setDestinationPort(int destinationPort) {
 		this.destinationPort = destinationPort;
-	}
-
-	public void setPort(int port) {
-		this.port  = port;
-		
-	}
-
-	public int getPort() {
-		return port;
 	}
 
 

--- a/jsystem-core-system-objects/cli-so/src/main/java/systemobject/terminal/SSHWithRSA.java
+++ b/jsystem-core-system-objects/cli-so/src/main/java/systemobject/terminal/SSHWithRSA.java
@@ -22,16 +22,13 @@ public class SSHWithRSA extends SSH {
 		privateKeyFile = privateKey;
 
 	}
+
 	@Override
 	public void connect() throws IOException {
-		connect(port);
-	}
-	@Override
-	public void connect(int port) throws IOException {
 		boolean isAuthenticated = false;
 		/* Create a connection instance */
 		System.out.println("Connet to Host with SSH and RSA private key");
-		conn = new Connection(hostname, port);
+		conn = new Connection(hostname);
 
 		/* Now connect */
 

--- a/jsystem-core-system-objects/cli-so/src/main/java/systemobject/terminal/Terminal.java
+++ b/jsystem-core-system-objects/cli-so/src/main/java/systemobject/terminal/Terminal.java
@@ -24,7 +24,6 @@ public abstract class Terminal {
     ArrayList<Prompt> prompts = new ArrayList<Prompt>();
 
     public abstract void connect() throws IOException;
-    public abstract void connect(int port) throws IOException;
     public abstract void disconnect() throws IOException;
     public abstract boolean isConnected();
     public abstract String getConnectionName();


### PR DESCRIPTION
Reverts Top-Q/jsystem#262

Reverts due to:

~~~~
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.5.1:compile (default-compile) on project
 cli: Compilation failure: Compilation failure:
[ERROR] C:\Users\itaya\git\jsystem\jsystem-core-system-objects\cli-so\src\main\java\systemobject\terminal\Cmd.java:[25,7
] error: Cmd is not abstract and does not override abstract method connect(int) in Terminal
[ERROR] C:\Users\itaya\git\jsystem\jsystem-core-system-objects\cli-so\src\main\java\systemobject\terminal\Telnet.java:[1
4,7] error: Telnet is not abstract and does not override abstract method connect(int) in Terminal
[ERROR] C:\Users\itaya\git\jsystem\jsystem-core-system-objects\cli-so\src\main\java\systemobject\terminal\RS232.java:[19
,7] error: RS232 is not abstract and does not override abstract method connect(int) in Terminal
[ERROR] C:\Users\itaya\git\jsystem\jsystem-core-system-objects\cli-so\src\main\java\systemobject\terminal\SSH.java:[18,7
] error: SSH is not abstract and does not override abstract method connect() in Terminal
[ERROR] C:\Users\itaya\git\jsystem\jsystem-core-system-objects\cli-so\src\main\java\systemobject\terminal\SSHWithRSA.jav
a:[61,8] error: abstract method connect() in Terminal cannot be accessed directly
~~~~