### PR TITLE
Java 17

### DIFF
--- a/jsystem-archetypes/jsystem-so-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/jsystem-archetypes/jsystem-so-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,8 +7,8 @@
 	<properties>
 		<jsystem.version>${jsystem.dependency.version}</jsystem.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 	<repositories>
 		<repository>

--- a/jsystem-archetypes/jsystem-tests-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/jsystem-archetypes/jsystem-tests-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,8 +7,8 @@
 	<properties>
 		<jsystem.version>${jsystem.dependency.version}</jsystem.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 	<repositories>
 		<repository>

--- a/jsystem-assembly/jsystem-runner/pom.xml
+++ b/jsystem-assembly/jsystem-runner/pom.xml
@@ -13,6 +13,25 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                </dependency>
+		<dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                    <version>2.3.0.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                    <version>2.3.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                    <version>3.25.0-GA</version>
+                </dependency>
 		<dependency>
 			<groupId>ant</groupId>
 			<artifactId>ant-full</artifactId>

--- a/jsystem-assembly/jsystem-runner/pom.xml
+++ b/jsystem-assembly/jsystem-runner/pom.xml
@@ -77,11 +77,6 @@
 			<artifactId>comm</artifactId>
 			<!-- type>pom</type -->
 		</dependency>
-		<!-- dependency> <groupId>org.apache.ftpserver</groupId> <artifactId>ftpserver-core</artifactId> 
-			<version>1.0.0</version> </dependency> <dependency> <groupId>org.apache.ftpserver</groupId> 
-			<artifactId>ftplet-api</artifactId> <version>1.0.0</version> </dependency> 
-			<dependency> <groupId>org.apache.ftpserver</groupId> <artifactId>ftpserver-deprecated</artifactId> 
-			<version>1.0.0-M2</version> </dependency -->
 		<dependency>
 			<groupId>org.apache.ftpserver</groupId>
 			<artifactId>ftpserver-core</artifactId>
@@ -174,8 +169,31 @@
 			<version>${project.version}</version>
 			<classifier>sources</classifier>
 		</dependency>
-
-
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.woodstox</groupId>
+			<artifactId>stax2-api</artifactId>
+			<version>4.2.2</version>
+		</dependency>
 	</dependencies>
 
 	<packaging>jar</packaging>

--- a/jsystem-assembly/jsystem-runner/src/main/assembly/runner.xml
+++ b/jsystem-assembly/jsystem-runner/src/main/assembly/runner.xml
@@ -126,6 +126,8 @@
 				<include>*:jackson-databind:*</include>
 				<include>*:jackson-annotations:*</include>
 				<include>*:jackson-core:*</include>
+				<include>*:jackson-dataformat-xml:*</include>
+				<include>*:stax2-api:*</include>
 				<include>*:difido-reports-common:*</include>
 			</includes>
 		</dependencySet>

--- a/jsystem-assembly/jsystem-runner/src/main/assembly/runner.xml
+++ b/jsystem-assembly/jsystem-runner/src/main/assembly/runner.xml
@@ -128,6 +128,10 @@
 				<include>*:jackson-core:*</include>
 				<include>*:jackson-dataformat-xml:*</include>
 				<include>*:stax2-api:*</include>
+				<include>*:jaxb-api:*</include>
+				<include>*:jaxb-core:*</include>
+				<include>*:jaxb-impl:*</include>
+				<include>*:javassist:*</include>
 				<include>*:difido-reports-common:*</include>
 			</includes>
 		</dependencySet>

--- a/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/WaitDialog.java
+++ b/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/WaitDialog.java
@@ -23,8 +23,6 @@ import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.SwingWorker;
 
-import sun.awt.AppContext;
-
 import jsystem.framework.TestRunnerFrame;
 
 /**
@@ -177,9 +175,6 @@ public class WaitDialog extends JDialog {
 		/*
 		 * Execute the open of the dialog in a thread as the dialog is modal
 		 */
-		// This line suppose to fix bug in the SwingWorker that causes deadlocks
-		// in some of the Java versions. Please see http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6880336
-		AppContext.getAppContext().put(SwingWorker.class, Executors.newCachedThreadPool());
 		dialog = new WaitDialog(TestRunnerFrame.guiMainFrame, listener, title);
 		class RunWaitDiaolg extends SwingWorker<String, Object> {
 			public String doInBackground() {

--- a/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/agents/AgentsDialog.java
+++ b/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/agents/AgentsDialog.java
@@ -145,7 +145,7 @@ public class AgentsDialog extends JDialog {
 	}
 
 	private void buildAgentsListTableModel() throws Exception {
-		Vector<Object> model = new Vector<Object>();
+		Vector<Vector<Object>> model = new Vector<Vector<Object>>();
 		RunnerEngine[] clients = JSystemAgentClientsPool.getClients(null);
 		for (RunnerEngine client : clients) {
 			Vector<Object> clientRow = getJSystemAgentDataVector(client, false);
@@ -231,7 +231,7 @@ public class AgentsDialog extends JDialog {
 	}
 
 	class AgentListTableModel extends DefaultTableModel {
-		AgentListTableModel(Vector<Object> model, Vector<String> columns) {
+		AgentListTableModel(Vector<Vector<Object>> model, Vector<String> columns) {
 			super(model, columns);
 		}
 

--- a/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/params/AgentsSelectionDialog.java
+++ b/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/params/AgentsSelectionDialog.java
@@ -85,7 +85,7 @@ public class AgentsSelectionDialog extends JDialog {
 	}
 
 	private void buildAgentsListTableModel() throws Exception {
-		Vector<Object> model = new Vector<Object>();
+		Vector<Vector<Object>> model = new Vector<Vector<Object>>();
 		JSystemAgentClient[] clients = (JSystemAgentClient[]) JSystemAgentClientsPool.getClients(null);
 		for (JSystemAgentClient client : clients) {
 			Vector<Object> clientRow = getJSystemAgentDataVector(client);
@@ -132,7 +132,7 @@ public class AgentsSelectionDialog extends JDialog {
 	class AgentSelectTableModel extends DefaultTableModel {
 		private static final long serialVersionUID = 1L;
 
-		AgentSelectTableModel(Vector<Object> model, Vector<String> columns) {
+		AgentSelectTableModel(Vector<Vector<Object>> model, Vector<String> columns) {
 			super(model, columns);
 		}
 

--- a/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/teststable/ScenarioTreeNode.java
+++ b/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/teststable/ScenarioTreeNode.java
@@ -88,7 +88,7 @@ public class ScenarioTreeNode implements TreeNode {
 		return (!isJTestContainer() || ScenarioHelpers.isScenarioAsTestAndNotRoot(getTest()));
 	}
 
-	public Enumeration<?> children() {
+	public Enumeration<? extends TreeNode> children() {
 		Vector<ScenarioTreeNode> elements = new Vector<ScenarioTreeNode>();
 		Vector<JTest> tests = null;
 		if (isJTestContainer()) {

--- a/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/tree/AssetNode.java
+++ b/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/tree/AssetNode.java
@@ -88,7 +88,7 @@ public abstract class AssetNode extends DefaultMutableTreeNode implements Compar
 	public AssetNode(){
 		isSelected = false;
 		if (children == null) {
-			children = new Vector<AssetNode>();
+			children = new Vector();
 		}
 	}
 
@@ -246,7 +246,7 @@ public abstract class AssetNode extends DefaultMutableTreeNode implements Compar
 			}
 		}
 		if("true".equals(JSystemProperties.getInstance().getPreferenceOrDefault(FrameworkOptions.SORT_ASSETS_TREE))){
-			Collections.sort(children);
+			Collections.sort(children, null);
 		}
 	}
 

--- a/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/tree/TestCaseNode.java
+++ b/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/tree/TestCaseNode.java
@@ -36,7 +36,7 @@ public class TestCaseNode extends AssetNode {
 			createJUnit4TestNodes(userObject);
 		}
 		if("true".equals(JSystemProperties.getInstance().getPreferenceOrDefault(FrameworkOptions.SORT_ASSETS_TREE))){
-			Collections.sort(children);
+			Collections.sort(children, null);
 		}
 	}
 

--- a/jsystem-core-projects/jsystemCore/pom.xml
+++ b/jsystem-core-projects/jsystemCore/pom.xml
@@ -74,6 +74,22 @@
 			<groupId>xml-apis</groupId>
 			<artifactId>xml-apis</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/jsystem-core-projects/jsystemCore/pom.xml
+++ b/jsystem-core-projects/jsystemCore/pom.xml
@@ -90,6 +90,16 @@
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-xml</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/junit/JUnitReporter.java
+++ b/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/junit/JUnitReporter.java
@@ -2,7 +2,7 @@ package jsystem.extensions.report.junit;
 
 import java.io.File;
 import java.io.IOException;
-
+import java.io.StringWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
 
 import jsystem.extensions.report.xml.XmlReporter;
 import jsystem.framework.FrameworkOptions;
@@ -140,11 +140,13 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 	public void toXml() {
 		testSuite.setTime(getTimeDeltaInSec(testSuiteStart));
 		try {
-			XmlMapper xmlMapper = new XmlMapper();
-			String xmlString = xmlMapper.writeValueAsString(testSuite);
+			JAXBContext context = JAXBContext.newInstance(testSuite.getClass());
+			Marshaller marshaller = context.createMarshaller();
+			StringWriter sw = new StringWriter();
+			marshaller.marshal(testSuite, sw);
 			final String currentLogFolder = JSystemProperties.getInstance().getPreference(FrameworkOptions.LOG_FOLDER)
 					+ File.separator + "current";
-			FileUtils.write(currentLogFolder + File.separator + logFileName, xmlString);
+			FileUtils.write(currentLogFolder + File.separator + logFileName, sw.toString());
 		} catch (Exception e) {
 			log.log(Level.SEVERE, "Failed to export report to XML", e);
 		}
@@ -175,7 +177,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 
 		private FailureOrError error;
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public String getName() {
 			return name;
 		}
@@ -184,7 +186,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.name = name;
 		}
 
-		@JacksonXmlProperty(isAttribute = true, localName = "classname")
+		@XmlAttribute(name = "classname")
 		public String getClassName() {
 			return className;
 		}
@@ -193,7 +195,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.className = className;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public float getTime() {
 			return time;
 		}
@@ -202,7 +204,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.time = time;
 		}
 
-		@JsonProperty
+		@XmlElement
 		public FailureOrError getFailure() {
 			return failure;
 		}
@@ -211,7 +213,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.failure = failure;
 		}
 
-		@JsonProperty
+		@XmlElement
 		public FailureOrError getError() {
 			return error;
 		}
@@ -222,7 +224,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 
 	}
 
-	@JacksonXmlRootElement(localName = "testsuite")
+	@XmlRootElement(name = "testsuite")
 	static class TestSuite {
 
 		private int errors;
@@ -237,8 +239,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 
 		private String timeStamp;
 
-		@JacksonXmlElementWrapper(useWrapping = false)
-		@JsonProperty("testcase")
+		@XmlElement(name = "testcase")
 		protected List<TestCase> testCaseList = new ArrayList<TestCase>();
 
 		public TestCase getLastTestCase() {
@@ -258,7 +259,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			testCaseList.add(testCase);
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public int getErrors() {
 			return errors;
 		}
@@ -267,7 +268,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			errors++;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public int getFailures() {
 			return failures;
 		}
@@ -276,7 +277,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.failures = failures;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public String getHostName() {
 			return hostName;
 		}
@@ -285,7 +286,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.hostName = hostName;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public String getName() {
 			return name;
 		}
@@ -294,12 +295,12 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.name = name;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public String getTimeStamp() {
 			return timeStamp;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public float getTime() {
 			return time;
 		}
@@ -312,7 +313,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.timeStamp = timeStamp;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public int getTests() {
 			return testCaseList.size();
 		}
@@ -324,7 +325,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 		private String message;
 		private String type;
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public String getMessage() {
 			return message;
 		}
@@ -333,7 +334,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.message = message;
 		}
 
-		@JacksonXmlProperty(isAttribute = true)
+		@XmlAttribute
 		public String getType() {
 			return type;
 		}
@@ -342,7 +343,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.type = type;
 		}
 
-		@JacksonXmlText
+		@XmlValue
 		public String getValue() {
 			return value;
 		}

--- a/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/junit/JUnitReporter.java
+++ b/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/junit/JUnitReporter.java
@@ -2,7 +2,7 @@ package jsystem.extensions.report.junit;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringWriter;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 
 import jsystem.extensions.report.xml.XmlReporter;
 import jsystem.framework.FrameworkOptions;
@@ -134,19 +134,17 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 	}
 
 	/**
-	 * Exports the model to XML. The file will be copies to the JSystem root
+	 * Exports the model to XML. The file will be copied to the JSystem root
 	 * directory.
 	 */
 	public void toXml() {
 		testSuite.setTime(getTimeDeltaInSec(testSuiteStart));
 		try {
-			JAXBContext context = JAXBContext.newInstance(testSuite.getClass());
-			Marshaller marshaller = context.createMarshaller();
-			StringWriter sw = new StringWriter();
-			marshaller.marshal(testSuite, sw);
+			XmlMapper xmlMapper = new XmlMapper();
+			String xmlString = xmlMapper.writeValueAsString(testSuite);
 			final String currentLogFolder = JSystemProperties.getInstance().getPreference(FrameworkOptions.LOG_FOLDER)
 					+ File.separator + "current";
-			FileUtils.write(currentLogFolder + File.separator + logFileName, sw.toString());
+			FileUtils.write(currentLogFolder + File.separator + logFileName, xmlString);
 		} catch (Exception e) {
 			log.log(Level.SEVERE, "Failed to export report to XML", e);
 		}
@@ -177,7 +175,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 
 		private FailureOrError error;
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getName() {
 			return name;
 		}
@@ -186,7 +184,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.name = name;
 		}
 
-		@XmlAttribute(name = "classname")
+		@JacksonXmlProperty(isAttribute = true, localName = "classname")
 		public String getClassName() {
 			return className;
 		}
@@ -195,7 +193,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.className = className;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public float getTime() {
 			return time;
 		}
@@ -204,7 +202,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.time = time;
 		}
 
-		@XmlElement
+		@JsonProperty
 		public FailureOrError getFailure() {
 			return failure;
 		}
@@ -213,7 +211,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.failure = failure;
 		}
 
-		@XmlElement
+		@JsonProperty
 		public FailureOrError getError() {
 			return error;
 		}
@@ -224,7 +222,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 
 	}
 
-	@XmlRootElement(name = "testsuite")
+	@JacksonXmlRootElement(localName = "testsuite")
 	static class TestSuite {
 
 		private int errors;
@@ -239,7 +237,8 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 
 		private String timeStamp;
 
-		@XmlElement(name = "testcase")
+		@JacksonXmlElementWrapper(useWrapping = false)
+		@JsonProperty("testcase")
 		protected List<TestCase> testCaseList = new ArrayList<TestCase>();
 
 		public TestCase getLastTestCase() {
@@ -259,7 +258,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			testCaseList.add(testCase);
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public int getErrors() {
 			return errors;
 		}
@@ -268,7 +267,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			errors++;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public int getFailures() {
 			return failures;
 		}
@@ -277,7 +276,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.failures = failures;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getHostName() {
 			return hostName;
 		}
@@ -286,7 +285,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.hostName = hostName;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getName() {
 			return name;
 		}
@@ -295,12 +294,12 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.name = name;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getTimeStamp() {
 			return timeStamp;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public float getTime() {
 			return time;
 		}
@@ -313,7 +312,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.timeStamp = timeStamp;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public int getTests() {
 			return testCaseList.size();
 		}
@@ -325,7 +324,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 		private String message;
 		private String type;
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getMessage() {
 			return message;
 		}
@@ -334,7 +333,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.message = message;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getType() {
 			return type;
 		}
@@ -343,7 +342,7 @@ public class JUnitReporter implements ExtendTestReporter, ExtendTestListener {
 			this.type = type;
 		}
 
-		@XmlValue
+		@JacksonXmlText
 		public String getValue() {
 			return value;
 		}

--- a/jsystem-core-projects/jsystemCore/src/main/java/jsystem/utils/Encryptor.java
+++ b/jsystem-core-projects/jsystemCore/src/main/java/jsystem/utils/Encryptor.java
@@ -3,6 +3,7 @@
  */
 package jsystem.utils;
 
+import java.util.Base64;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -48,7 +49,7 @@ public class Encryptor {
 		byte[] enc = ecipher.doFinal(utf8);
 
 		// Encode bytes to base64 to get a string
-		return (new sun.misc.BASE64Encoder().encode(enc))+ENCRYPTION_TERMINATING_STRING;
+		return Base64.getEncoder().encode(enc)+ENCRYPTION_TERMINATING_STRING;
 	}
 
 	/**
@@ -70,7 +71,7 @@ public class Encryptor {
 		ecipher.init(Cipher.ENCRYPT_MODE, key);
 		dcipher.init(Cipher.DECRYPT_MODE, key);
 		// Decode base64 to get bytes
-		byte[] dec = new sun.misc.BASE64Decoder().decodeBuffer(str);
+		byte[] dec = Base64.getDecoder().decode(str);
 
 		// Decrypt
 		byte[] utf8 = dcipher.doFinal(dec);

--- a/jsystem-core-projects/jsystemCore/src/main/java/jsystem/utils/MailUtil.java
+++ b/jsystem-core-projects/jsystemCore/src/main/java/jsystem/utils/MailUtil.java
@@ -4,7 +4,7 @@
 package jsystem.utils;
 
 import java.io.File;
-import java.security.Security;
+
 import java.util.ArrayList;
 import java.util.Properties;
 
@@ -168,8 +168,6 @@ public class MailUtil extends SystemObjectImpl{
 			props.put("mail.smtp.socketFactory.class", SSL_FACTORY);
 			props.put("mail.smtp.socketFactory.fallback", "false");
 		}
-
-		Security.addProvider(new com.sun.net.ssl.internal.ssl.Provider());
 
 		props.put("mail.smtp.host", smtpHostName);
 

--- a/jsystem-core-projects/pom.xml
+++ b/jsystem-core-projects/pom.xml
@@ -20,5 +20,26 @@
 		<module>jsystemAgent</module>
 		<module>jsystemApp</module>
 	</modules>
-	
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/jsystem-core-projects/pom.xml
+++ b/jsystem-core-projects/pom.xml
@@ -41,5 +41,10 @@
 			<artifactId>jackson-dataformat-xml</artifactId>
 			<version>2.15.2</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/jsystem-miscellaneous/jsystem-maven-plugin/pom.xml
+++ b/jsystem-miscellaneous/jsystem-maven-plugin/pom.xml
@@ -60,6 +60,22 @@
 			<version>2.0.2</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/jsystem-miscellaneous/jsystem-maven-plugin/src/main/java/org/jsystemtest/plugin/SurefireReporter.java
+++ b/jsystem-miscellaneous/jsystem-maven-plugin/src/main/java/org/jsystemtest/plugin/SurefireReporter.java
@@ -2,7 +2,7 @@ package org.jsystemtest.plugin;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringWriter;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 
 import jsystem.extensions.report.xml.XmlReporter;
 import jsystem.framework.report.ExtendTestListener;
@@ -146,12 +146,10 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 	public void toXml() {
 		testSuite.setTime(getTimeDeltaInSec(testSuiteStart));
 		try {
-			JAXBContext context = JAXBContext.newInstance(testSuite.getClass());
-			Marshaller marshaller = context.createMarshaller();
-			StringWriter sw = new StringWriter();
-			marshaller.marshal(testSuite, sw);
-			FileUtils.write(logFolderName + File.separator + logFileName, sw.toString());
-			FileUtils.write(logFileName, sw.toString());
+			XmlMapper xmlMapper = new XmlMapper();
+			String xmlString = xmlMapper.writeValueAsString(testSuite);
+			FileUtils.write(logFolderName + File.separator + logFileName, xmlString);
+			FileUtils.write(logFileName, xmlString);
 		} catch (Exception e) {
 			log.log(Level.SEVERE, "Failed to export report to XML", e);
 		}
@@ -182,7 +180,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 
 		private FailureOrError error;
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getName() {
 			return name;
 		}
@@ -191,7 +189,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.name = name;
 		}
 
-		@XmlAttribute(name = "classname")
+		@JacksonXmlProperty(isAttribute = true, localName = "classname")
 		public String getClassName() {
 			return className;
 		}
@@ -200,7 +198,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.className = className;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public float getTime() {
 			return time;
 		}
@@ -209,7 +207,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.time = time;
 		}
 
-		@XmlElement
+		@JsonProperty
 		public FailureOrError getFailure() {
 			return failure;
 		}
@@ -218,7 +216,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.failure = failure;
 		}
 
-		@XmlElement
+		@JsonProperty
 		public FailureOrError getError() {
 			return error;
 		}
@@ -229,7 +227,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 
 	}
 
-	@XmlRootElement(name = "testsuite")
+	@JacksonXmlRootElement(localName = "testsuite")
 	static class TestSuite {
 
 		private int errors;
@@ -244,7 +242,8 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 
 		private String timeStamp;
 
-		@XmlElement(name = "testcase")
+		@JacksonXmlElementWrapper(useWrapping = false)
+		@JsonProperty("testcase")
 		protected List<TestCase> testCaseList = new ArrayList<TestCase>();
 
 		public TestCase getLastTestCase() {
@@ -264,7 +263,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			testCaseList.add(testCase);
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public int getErrors() {
 			return errors;
 		}
@@ -273,7 +272,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			errors++;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public int getFailures() {
 			return failures;
 		}
@@ -282,7 +281,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.failures = failures;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getHostName() {
 			return hostName;
 		}
@@ -291,7 +290,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.hostName = hostName;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getName() {
 			return name;
 		}
@@ -300,12 +299,12 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.name = name;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getTimeStamp() {
 			return timeStamp;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public float getTime() {
 			return time;
 		}
@@ -318,7 +317,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.timeStamp = timeStamp;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public int getTests() {
 			return testCaseList.size();
 		}
@@ -330,7 +329,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 		private String message;
 		private String type;
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getMessage() {
 			return message;
 		}
@@ -339,7 +338,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.message = message;
 		}
 
-		@XmlAttribute
+		@JacksonXmlProperty(isAttribute = true)
 		public String getType() {
 			return type;
 		}
@@ -348,7 +347,7 @@ public class SurefireReporter implements ExtendTestReporter, ExtendTestListener 
 			this.type = type;
 		}
 
-		@XmlValue
+		@JacksonXmlText
 		public String getValue() {
 			return value;
 		}

--- a/jsystem-parent/pom.xml
+++ b/jsystem-parent/pom.xml
@@ -228,6 +228,11 @@
 				<artifactId>jackson-dataformat-xml</artifactId>
 				<version>2.15.2</version>
 			</dependency>
+			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>2.3.1</version>
+			</dependency>
 		</dependencies>
 
 

--- a/jsystem-parent/pom.xml
+++ b/jsystem-parent/pom.xml
@@ -29,8 +29,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<assembly.format>dir</assembly.format>
 		<topq.repository.rootUrl>https://maven.top-q.co.il</topq.repository.rootUrl>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -46,7 +46,6 @@
 				<artifactId>junit</artifactId>
 				<version>4.13.1</version>
 			</dependency>
-
 			<dependency>
 				<groupId>javax.mail</groupId>
 				<artifactId>mail</artifactId>
@@ -208,6 +207,26 @@
 				<groupId>xml-apis</groupId>
 				<artifactId>xml-apis</artifactId>
 				<version>1.4.01</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.15.2</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.15.2</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.15.2</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-xml</artifactId>
+				<version>2.15.2</version>
 			</dependency>
 		</dependencies>
 


### PR DESCRIPTION
- Updating the Java version to 17.
- Replacing JAXB with Jackson which is more up to date.
- Removed import sun.awt.AppContext which is not allowed any more due to Java module restrictions, and is not needed any more in newer Swing version.
- Removeed com.sun.security.sasl.Provider which is not needed any more since Java 9.
- Removed sun.misc.BASE64Encoder and using the SDK's Base64 support.
- Many small fixes due to the Java differences.