### PR TITLE
Replace java2html with JHighlight

### DIFF
--- a/jsystem-assembly/jsystem-install/jsystemGeneric.install4j
+++ b/jsystem-assembly/jsystem-install/jsystemGeneric.install4j
@@ -90,7 +90,7 @@
           <entry location="thirdparty/lib/JainSipApi1.2.jar" fileType="regular" />
           <entry location="thirdparty/lib/JainSipRi1.2.jar" fileType="regular" />
           <entry location="thirdparty/lib/jars.txt" fileType="regular" />
-          <entry location="thirdparty/lib/java2html.jar" fileType="regular" />
+          <entry location="thirdparty/commonLib/jhighlight.jar" fileType="regular" />
           <entry location="thirdparty/lib/java-getopt-1.0.12.jar" fileType="regular" />
           <entry location="thirdparty/lib/javacsv.jar" fileType="regular" />
           <entry location="thirdparty/lib/javadoc_net.sourceforge.jpcap-0.01.16.jar" fileType="regular" />

--- a/jsystem-assembly/jsystem-runner/pom.xml
+++ b/jsystem-assembly/jsystem-runner/pom.xml
@@ -108,6 +108,10 @@
 
 		</dependency>
 		<dependency>
+			<groupId>org.codelibs</groupId>
+			<artifactId>jhighlight</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>net.javaprog.jwizz</groupId>
 			<artifactId>jwizz</artifactId>
 

--- a/jsystem-assembly/jsystem-runner/src/main/assembly/runner.xml
+++ b/jsystem-assembly/jsystem-runner/src/main/assembly/runner.xml
@@ -93,6 +93,7 @@
 				<include>*:logkit:*</include>
 				<include>*:mail:*</include>
 				<include>*:qdox:*</include>
+				<include>*:jhighlight:*</include>
 				<include>*:serializer:*</include>
 				<include>*:servlet-api:*</include>
 				<include>*:spring:*</include>

--- a/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/teststable/TestsTableController.java
+++ b/jsystem-core-projects/jsystemApp/src/main/java/jsystem/treeui/teststable/TestsTableController.java
@@ -1300,9 +1300,9 @@ public class TestsTableController extends Observable implements TestStatusListen
 			JOptionPane
 					.showMessageDialog(
 							null,
-							"Can't display test code because java2html.jar is missing.\nIf you wish to view code, please install java2html.jar. For instructions go to http://trac.jsystemtest.org/wiki/DetailedOSProjectsList",
+							"Can't display test code because JHighlight is missing from the runtime classpath.",
 							"View Test Code warning", JOptionPane.INFORMATION_MESSAGE);
-			log.log(Level.WARNING, "Fail to load test code because java2html jar is missing. " + e.getMessage());
+			log.log(Level.WARNING, "Fail to load test code because JHighlight is missing. " + e.getMessage());
 		} catch (Exception e) {
 			log.log(Level.WARNING, "Fail to load test code. " + e.getMessage());
 		}

--- a/jsystem-core-projects/jsystemCore/pom.xml
+++ b/jsystem-core-projects/jsystemCore/pom.xml
@@ -45,6 +45,10 @@
 			<artifactId>qdox</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.codelibs</groupId>
+			<artifactId>jhighlight</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>il.co.top-q.difido</groupId>
 			<artifactId>difido-reports-common</artifactId>
 		</dependency>

--- a/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/html/HtmlCodeWriter.java
+++ b/jsystem-core-projects/jsystemCore/src/main/java/jsystem/extensions/report/html/HtmlCodeWriter.java
@@ -5,11 +5,10 @@ package jsystem.extensions.report.html;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.io.Writer;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -18,6 +17,8 @@ import jsystem.framework.FrameworkOptions;
 import jsystem.framework.JSystemProperties;
 import jsystem.runner.loader.LoadersManager;
 import jsystem.utils.FileUtils;
+
+import org.codelibs.jhighlight.renderer.JavaXhtmlRenderer;
 
 import com.thoughtworks.qdox.JavaDocBuilder;
 import com.thoughtworks.qdox.model.DocletTag;
@@ -112,7 +113,7 @@ public class HtmlCodeWriter {
 	 * Get the test code formated as HTML.
 	 * @param className the test class name.
 	 * @return an html with the code formated.
-	 * @throws Exception when java2html class is missing, the file is not found or other error occurs
+	 * @throws Exception when JHighlight is missing, the file is not found or other error occurs
 	 */
 	public String getCode(String className) throws FileNotFoundException, ClassNotFoundException, Exception {
 		File srcFile = new File(srcDir.getPath(), className.replace('.', File.separatorChar) + ".java");
@@ -122,39 +123,21 @@ public class HtmlCodeWriter {
 				throw new FileNotFoundException(srcFile.getPath());
 			}
 		}
-		// Create a reader of the raw input text
 
-		// Parse the raw text to a JavaSource object
-
-		Class<?> sourceParserClass = LoadersManager.getInstance().getLoader().loadClass("de.java2html.javasource.JavaSourceParser");
-		Object sourceParser = sourceParserClass.newInstance();
-		Method parseMethod = sourceParserClass.getMethod("parse", File.class);
-		if (parseMethod == null) {
-			return "";
-		}
-		Object source = parseMethod.invoke(sourceParser, srcFile);
-		if (source == null) {
-			return "";
-		}
-		Class<?> converterClass = LoadersManager.getInstance().getLoader().loadClass("de.java2html.converter.JavaSource2HTMLConverter");
-		StringWriter writer = new StringWriter();
-		Object converter = converterClass.getConstructor(source.getClass()).newInstance(source);
-		converterClass.getMethod("convert", Writer.class).invoke(converter, writer);
-		
-		
-//		JavaSource source = null;
-//		source = new JavaSourceParser().parse(srcFile);
-
-		// Create a converter and write the JavaSource object as Html
-//		JavaSource2HTMLConverter converter = new JavaSource2HTMLConverter(source);
-//		StringWriter writer = new StringWriter();
-//		converter.convert(writer);
 		String toReturn = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\">\n" + "<html><head>\n" +
 		// "<title></title>\n" +
-				"</head>\n" + "<body>\n" + writer.toString() + "</body>\n" + "</html>\n";
+				"</head>\n" + "<body>\n" + formatSourceAsHtml(srcFile) + "</body>\n" + "</html>\n";
 
 		return toReturn;
 
+	}
+
+	static String formatSourceAsHtml(File srcFile) throws ClassNotFoundException, IOException {
+		try {
+			return new JavaXhtmlRenderer().highlight(srcFile.getName(), FileUtils.read(srcFile), "UTF-8", true);
+		} catch (NoClassDefFoundError e) {
+			throw new ClassNotFoundException("JHighlight is missing from the runtime classpath", e);
+		}
 	}
 	
 	/**

--- a/jsystem-core-projects/jsystemCore/src/main/java/jsystem/framework/report/RunnerListenersManager.java
+++ b/jsystem-core-projects/jsystemCore/src/main/java/jsystem/framework/report/RunnerListenersManager.java
@@ -885,10 +885,10 @@ public class RunnerListenersManager extends DefaultReporterImpl implements JSyst
 				log.log(Level.WARNING, "Fail to load test code because source file is missing. " + e.getMessage());
 			} catch (ClassNotFoundException e) {
 				reportHtml(
-						"Can't display test code because java2html.jar is missing.",
-						"If you wish to view code, please install java2html.jar. For instructions go to <a href=\"http://trac.jsystemtest.org/wiki/DetailedOSProjectsList\">JSystem Trac</a>",
+						"Can't display test code because JHighlight is missing.",
+						"JHighlight must be available on the runtime classpath to render source code.",
 						true);
-				log.log(Level.WARNING, "Fail to load test code because java2html jar is missing. " + e.getMessage());
+				log.log(Level.WARNING, "Fail to load test code because JHighlight is missing. " + e.getMessage());
 			} catch (Exception e) {
 				log.log(Level.WARNING, "Fail to load test code. " + e.getMessage());
 			}

--- a/jsystem-core-projects/jsystemCore/src/test/java/jsystem/extensions/report/html/HtmlCodeWriterTest.java
+++ b/jsystem-core-projects/jsystemCore/src/test/java/jsystem/extensions/report/html/HtmlCodeWriterTest.java
@@ -1,0 +1,37 @@
+package jsystem.extensions.report.html;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.junit.Test;
+
+public class HtmlCodeWriterTest {
+
+	@Test
+	public void testFormatSourceAsHtmlUsesJHighlight() throws Exception {
+		File source = File.createTempFile("HtmlCodeWriterTest", ".java");
+		try {
+			FileWriter writer = new FileWriter(source);
+			try {
+				writer.write("public class HtmlCodeWriterTest {\n");
+				writer.write("\tpublic void sampleMethod() {\n");
+				writer.write("\t\tString value = \"hello\";\n");
+				writer.write("\t}\n");
+				writer.write("}\n");
+			} finally {
+				writer.close();
+			}
+
+			String html = HtmlCodeWriter.formatSourceAsHtml(source);
+
+			assertTrue(html.contains("sampleMethod"));
+			assertTrue(html.contains("<span"));
+			assertFalse(html.contains("de.java2html"));
+		} finally {
+			source.delete();
+		}
+	}
+}

--- a/jsystem-parent/pom.xml
+++ b/jsystem-parent/pom.xml
@@ -179,6 +179,11 @@
 				<version>1.9.2</version>
 			</dependency>
 			<dependency>
+				<groupId>org.codelibs</groupId>
+				<artifactId>jhighlight</artifactId>
+				<version>1.1.1</version>
+			</dependency>
+			<dependency>
 				<groupId>net.javaprog.jwizz</groupId>
 				<artifactId>jwizz</artifactId>
 				<version>0.1.3</version>


### PR DESCRIPTION
## Summary

This PR replaces the legacy `java2html.jar` source-code HTML rendering path with the maintained Maven dependency `org.codelibs:jhighlight:1.1.1`.

What changed:
- Added `org.codelibs:jhighlight:1.1.1` to parent dependency management.
- Added JHighlight as a `jsystemCore` dependency so `HtmlCodeWriter` can render source directly.
- Added JHighlight as a runner dependency and included it in the runner assembly under `thirdparty/commonLib/jhighlight.jar`.
- Updated install4j packaging to include `thirdparty/commonLib/jhighlight.jar` instead of `thirdparty/lib/java2html.jar`.
- Replaced the reflective `de.java2html.*` parser/converter calls in `HtmlCodeWriter` with `JavaXhtmlRenderer`.
- Updated user-facing/log messages that previously referenced `java2html.jar`.
- Added `HtmlCodeWriterTest` to verify Java source is rendered through JHighlight.

## Compatibility notes

- `JHighlight 1.1.1` was selected intentionally because it is Java 8 bytecode compatible (`major version: 52`) and therefore remains compatible with both current `master` and the Java 11 migration path.
- `JHighlight 2.0.0` was checked but not used because it targets Java 17, which would skip over the requested Java 11 compatibility step.
- No local/internal Maven POM configuration changes are included.

## Verification

Passed:
- `mvn -f jsystem-core-projects\pom.xml -pl jsystemCore -am -DskipTests package` using JDK 8
- `mvn -f jsystem-core-projects\pom.xml -pl jsystemCore "-Dtest=jsystem.extensions.report.html.HtmlCodeWriterTest" test` using JDK 8
- `mvn -f jsystem-core-projects\pom.xml -pl jsystemCore "-Dincludes=org.codelibs:jhighlight" dependency:tree` confirmed `org.codelibs:jhighlight:jar:1.1.1:compile`
- `git diff --cached --check`
- Staged diff scan for common secret/personal-data markers found no matches
- `git grep -n -i "java2html\|de\.java2html" -- . ':!*.jar' ':!*.class'` found no remaining source references

Known current-master/environment test noise:
- The full `mvn -f jsystem-core-projects\pom.xml -pl jsystemCore -am test` run compiled successfully and the new `HtmlCodeWriterTest` passed, but the broader legacy suite failed on existing environment-dependent tests: missing generated `META-INF/jsystemCore.build.properties`, missing `report8.html`, and no local POP3 server for `PublishTest`.

## Upgrade plan

1. Merge the Java 11 compatibility PR first if Java 11 validation is required on `master`.
2. Rebase this branch on the Java 11-ready base.
3. Re-run the same focused JHighlight test plus the full module test suite under JDK 11.
4. Keep JHighlight at `1.1.1` until the project intentionally moves beyond Java 11, because newer JHighlight currently requires Java 17.